### PR TITLE
🐛 Fix `no-unused-vars` lint error in intentional lint files

### DIFF
--- a/tests/exempted/jsdoc/multiline-blocks.js
+++ b/tests/exempted/jsdoc/multiline-blocks.js
@@ -22,4 +22,5 @@ class AlphaLendsClass extends Object {
 
 module.exports = {
   alpha,
+  AlphaLendsClass,
 }

--- a/tests/linted/default$/jsdoc/multiline-blocks.js
+++ b/tests/linted/default$/jsdoc/multiline-blocks.js
@@ -34,4 +34,5 @@ function alphaFunc () {
 module.exports = {
   alpha,
   alphaFunc,
+  AlphaLendsClass,
 }


### PR DESCRIPTION
## Why

* See #224

## How

* in `tests/exempted/jsdoc/multiline-blocks.js`
* in `tests/linted/default$/jsdoc/multiline-blocks.js`
