### PR TITLE
🧹 Kick out `README.ja.md` from `files` field of `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "ESLint config by Open Reach Tech Inc.",
   "files": [
     "configurations/",
-    "README.ja.md",
     "types/"
   ],
   "main": "eslint.config.js",


### PR DESCRIPTION
# Why

* Close #372
