### PR TITLE
⚙️ Turn off `jsdoc/check-tag-names` ESLint rule

### DIFF
--- a/configurations/plugins/jsdoc.js
+++ b/configurations/plugins/jsdoc.js
@@ -6,6 +6,15 @@ export default {
   rules: {
     ...jsdocConfiguration.rules,
 
+    'jsdoc/check-tag-names': [
+      'off', // 'error'
+      {
+        definedTags: [],
+        enableFixer: true,
+        jsxTags: false,
+        typed: false,
+      },
+    ],
     'jsdoc/imports-as-dependencies': [
       'off', // 'error'
     ],

--- a/tests/exempted/jsdoc/check-tag-names.js
+++ b/tests/exempted/jsdoc/check-tag-names.js
@@ -1,0 +1,34 @@
+/* eslint-disable max-classes-per-file */
+
+/**
+ * Base class for testing JSDoc indentation.
+ *
+ * @template T - Type parameters for the base class. // ✅️ { excludeTags: ['template'] } of `jsdoc/check-indentation`
+ */
+class BaseClass {
+  // noop
+}
+
+/**
+ * Alpha class that extends BaseClass.
+ * ✅️ exempted `jsdoc/check-tag-names`
+ *
+ * @extends {BaseClass<string>}
+ */
+class AlphaClass extends BaseClass {
+  // noop
+}
+
+/**
+ * Beta function.
+ *
+ * @note Beta function. // ✅️ exempted `jsdoc/check-tag-names`
+ */
+function betaFunction () {
+  // noop
+}
+
+export default {
+  AlphaClass,
+  betaFunction,
+}


### PR DESCRIPTION
# Why

* Close #395
