### PR TITLE
⚙️ Turn off `jsdoc/valid-types` ESLint rule

### DIFF
--- a/configurations/plugins/jsdoc.js
+++ b/configurations/plugins/jsdoc.js
@@ -410,5 +410,14 @@ export default {
         escapeMarkdown: false,
       },
     ],
+    'jsdoc/valid-types': [
+      /*
+       * Syntax error in type: X extends typeof SampleClass ? X : never  jsdoc/valid-types
+       */
+      'off', // 'error'
+      {
+        allowEmptyNamepaths: true,
+      },
+    ],
   },
 }

--- a/tests/exempted/jsdoc/valid-types.js
+++ b/tests/exempted/jsdoc/valid-types.js
@@ -1,0 +1,49 @@
+/**
+ * AlphaClass is a class that does nothing.
+ */
+export default class AlphaClass {
+  /**
+   * Constructor for AlphaClass.
+   *
+   * @param {AlphaClassParams} params - Parameters for the class.
+   */
+  constructor ({
+    first,
+    second,
+  }) {
+    this.first = first
+    this.second = second
+  }
+
+  /**
+   * Factory method of this class.
+   * ✅️ exempted from `valid-types` rule
+   *
+   * @template {X extends typeof AlphaClass ? X : never} T, X
+   * @param {AlphaClassFactoryParams} params - Parameters for the class.
+   * @returns {InstanceType<T>} An instance of AlphaClass.
+   * @this {T}
+   */
+  static create ({
+    first,
+    second,
+  }) {
+    return /** @type {InstanceType<T>} */ (
+      new this({
+        first,
+        second,
+      })
+    )
+  }
+}
+
+/**
+ * @typedef {{
+ *   first: number
+ *   second: string
+ * }} AlphaClassParams
+ */
+
+/**
+ * @typedef {AlphaClassParams} AlphaClassFactoryParams
+ */


### PR DESCRIPTION
# Why

* Close #402