### PR TITLE
🧵 Adjust options of `no-restricted-syntax` to add kick out `Array#reverse()`

### DIFF
--- a/lib/configurations/core-rule-option-hash.js
+++ b/lib/configurations/core-rule-option-hash.js
@@ -110,11 +110,6 @@ const coreRuleOptionHash = {
       },
       {
         // object: 'Array',
-        property: 'reverse',
-        message: 'Use `Array#toReversed()` instead of `Array#reverse()`',
-      },
-      {
-        // object: 'Array',
         property: 'sort',
         message: 'Use `Array#toSorted()` instead of `Array#sort()`',
       },

--- a/lib/configurations/core-rule-option-hash.js
+++ b/lib/configurations/core-rule-option-hash.js
@@ -137,6 +137,10 @@ const coreRuleOptionHash = {
         message: 'Never use if in higher-order function',
       },
       {
+        selector: 'CallExpression[callee.type=MemberExpression][callee.property.name="reverse"]',
+        message: 'Never use Array#reverse()',
+      },
+      {
         selector: 'DoWhileStatement',
         message: 'Never use do-while',
       },

--- a/tests/linted/standard$/no-restricted-properties/$ArrayReverse.js
+++ b/tests/linted/standard$/no-restricted-properties/$ArrayReverse.js
@@ -1,7 +1,0 @@
-const entries = []
-
-entries.reverse() // ❌ `no-restricted-properties`
-
-export default {
-  entries,
-}

--- a/tests/linted/standard$/no-restricted-syntax/$noArrayReverse.js
+++ b/tests/linted/standard$/no-restricted-syntax/$noArrayReverse.js
@@ -1,0 +1,3 @@
+const numbers = [1, 3, 5]
+
+export default numbers.reverse()


### PR DESCRIPTION
# Why

* Close #493
