### PR TITLE
🧵 Adjust options of `no-restricted-syntax` to add kick out `Array#reverse()`

### DIFF
--- a/lib/configurations/core-rule-option-hash.js
+++ b/lib/configurations/core-rule-option-hash.js
@@ -108,11 +108,6 @@ const coreRuleOptionHash = {
         property: 'assign',
         message: 'Never use `Object.assign()`',
       },
-      {
-        // object: 'Array',
-        property: 'sort',
-        message: 'Use `Array#toSorted()` instead of `Array#sort()`',
-      },
     ],
   },
   'no-restricted-syntax': {

--- a/lib/configurations/core-rule-option-hash.js
+++ b/lib/configurations/core-rule-option-hash.js
@@ -136,6 +136,10 @@ const coreRuleOptionHash = {
         message: 'Never use Array#reverse()',
       },
       {
+        selector: 'CallExpression[callee.type=MemberExpression][callee.property.name="sort"]',
+        message: 'Never use Array#sort()',
+      },
+      {
         selector: 'DoWhileStatement',
         message: 'Never use do-while',
       },

--- a/tests/linted/standard$/array-callback-return.js
+++ b/tests/linted/standard$/array-callback-return.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-restricted-properties */
+/* eslint-disable no-restricted-syntax */
 
 const array = [1, 2, 3]
 
@@ -11,7 +11,6 @@ const arrayFindLast = array.findLast(it => {}) // ❌ `array-callback-return`
 const arrayFindLastIndex = array.findLastIndex(it => {}) // ❌ `array-callback-return`
 const arrayFlatMap = array.flatMap(it => {}) // ❌ `array-callback-return`
 
-// eslint-disable-next-line no-restricted-syntax
 const arrayForEach = array.forEach(it => {
   const over = it > 2
 

--- a/tests/linted/standard$/no-restricted-properties/$ArraySort.js
+++ b/tests/linted/standard$/no-restricted-properties/$ArraySort.js
@@ -1,7 +1,0 @@
-const entries = []
-
-entries.sort() // ❌ `no-restricted-properties`
-
-export default {
-  entries,
-}

--- a/tests/linted/standard$/no-restricted-syntax/$noArraySort.js
+++ b/tests/linted/standard$/no-restricted-syntax/$noArraySort.js
@@ -1,0 +1,3 @@
+const numbers = [1, 3, 5]
+
+export default numbers.sort()


### PR DESCRIPTION
# Why

* Close #495

