### PR TITLE
🧵 Adjust options of `no-restricted-syntax` rule for `Array#reverse()` and `Array#sort()`

### DIFF
--- a/lib/configurations/core-rule-option-hash.js
+++ b/lib/configurations/core-rule-option-hash.js
@@ -132,7 +132,7 @@ const coreRuleOptionHash = {
       },
       {
         selector: 'CallExpression[callee.type=MemberExpression][callee.property.name="sort"]',
-        message: 'Never use Array#sort()',
+        message: 'Use Array#toSorted() instead of Array#sort()',
       },
       {
         selector: 'DoWhileStatement',

--- a/lib/configurations/core-rule-option-hash.js
+++ b/lib/configurations/core-rule-option-hash.js
@@ -128,7 +128,7 @@ const coreRuleOptionHash = {
       },
       {
         selector: 'CallExpression[callee.type=MemberExpression][callee.property.name="reverse"]',
-        message: 'Never use Array#reverse()',
+        message: 'Use Array#toReversed() instead of Array#reverse()',
       },
       {
         selector: 'CallExpression[callee.type=MemberExpression][callee.property.name="sort"]',


### PR DESCRIPTION
# Why

* Close #503
