### PR TITLE
🧵 Adjust options of `no-restricted-syntax` for no short-circuit evaluation

### DIFF
--- a/lib/configurations/core-rule-option-hash.js
+++ b/lib/configurations/core-rule-option-hash.js
@@ -187,6 +187,10 @@ const coreRuleOptionHash = {
         message: 'Never use nested-if including else-if',
       },
       {
+        selector: 'LogicalExpression[operator=||] > Literal',
+        message: 'Do not use short-circuit evaluation with || operator',
+      },
+      {
         selector: 'SwitchStatement',
         message: 'Never use switch',
       },

--- a/tests/__tests__/verify-eslint-config.js
+++ b/tests/__tests__/verify-eslint-config.js
@@ -17,6 +17,7 @@ const messageHash = {
     noIdentifierWithItemSuffix: 'Not allowed to use "Item" as suffix of identifier',
     noIdentifierWithListSuffix: 'Not allowed to use "List" as suffix of identifier',
     noIdentifierWithManagerSuffix: 'Not allowed to use "Manager" as suffix of identifier',
+    noShortCircuitEvaluation: 'Do not use short-circuit evaluation with \\|\\| operator',
     noSwitch: 'Never use switch',
     noWhile: 'Never use while',
   },

--- a/tests/exempted/no-restricted-syntax.js
+++ b/tests/exempted/no-restricted-syntax.js
@@ -1,5 +1,15 @@
 const alpha = new FormData() // ✅️ ignore Identifier[name=/.+(?<!Form)Data$/] of `no-restricted-syntax` against FormData
 
+// -----------------------------------------------------------------------------
+
+// For no short-circuit evaluation with || operator
+/** @type {number} */
+const shortCircuitBaseValue = 999
+
+const betaValue = shortCircuitBaseValue === 0 || alpha.values // ✅️ { selector: 'LogicalExpression[operator=||] > Literal' } of `no-restricted-syntax`
+
+// -----------------------------------------------------------------------------
+
 const RequestInfo = class {} // ✅️ ignore Identifier[name=/.+(?<!Request)Info$/] of `no-restricted-syntax` against RequestInfo
 
 localStorage.getItem('key') // ✅️ ignore Identifier[name=/.+(?<!get|set|remove|named)Item$/] of `no-restricted-syntax` against getItem
@@ -25,6 +35,7 @@ transfer.clearData() // ✅️ { selector: 'Identifier[name=/.+(?<!Form|get|set|
 
 export default {
   alpha,
+  betaValue,
   RequestInfo,
   isRadioNodeList,
 }

--- a/tests/linted/standard$/no-restricted-syntax/$noShortCircuitEvaluation.js
+++ b/tests/linted/standard$/no-restricted-syntax/$noShortCircuitEvaluation.js
@@ -1,0 +1,13 @@
+const base = {}
+
+const alpha = base.value || null // ❌️ { selector: 'LogicalExpression[operator=||] > Literal' } of `no-restricted-syntax`
+
+const beta = base.status || true // ❌️ { selector: 'LogicalExpression[operator=||] > Literal' } of `no-restricted-syntax`
+
+const gamma = base.key || 'fallback' // ❌️ { selector: 'LogicalExpression[operator=||] > Literal' } of `no-restricted-syntax`
+
+export default {
+  alpha,
+  beta,
+  gamma,
+}


### PR DESCRIPTION
# Why

* Close #508