### PR TITLE
🧵 Adjust options of `no-restricted-syntax` rule for no short-circuit evaluation

### DIFF
--- a/lib/configurations/core-rule-option-hash.js
+++ b/lib/configurations/core-rule-option-hash.js
@@ -188,7 +188,7 @@ const coreRuleOptionHash = {
       },
       {
         selector: 'LogicalExpression[operator=||] > Literal',
-        message: 'Do not use short-circuit evaluation with || operator',
+        message: 'Use `??` instead of short-circuit evaluation with `||` operator',
       },
       {
         selector: 'SwitchStatement',

--- a/tests/__tests__/verify-eslint-config.js
+++ b/tests/__tests__/verify-eslint-config.js
@@ -17,7 +17,7 @@ const messageHash = {
     noIdentifierWithItemSuffix: 'Not allowed to use "Item" as suffix of identifier',
     noIdentifierWithListSuffix: 'Not allowed to use "List" as suffix of identifier',
     noIdentifierWithManagerSuffix: 'Not allowed to use "Manager" as suffix of identifier',
-    noShortCircuitEvaluation: 'Do not use short-circuit evaluation with \\|\\| operator',
+    noShortCircuitEvaluation: 'Use `\\?\\?` instead of short-circuit evaluation with `\\|\\|` operator',
     noSwitch: 'Never use switch',
     noWhile: 'Never use while',
   },


### PR DESCRIPTION
# Why

* Close #516