### PR TITLE
🧵 Adjust options of `no-restricted-syntax` to kick out ternary operator from `Array#forEach()`

### DIFF
--- a/lib/configurations/core-rule-option-hash.js
+++ b/lib/configurations/core-rule-option-hash.js
@@ -123,6 +123,10 @@ const coreRuleOptionHash = {
         message: 'Do not use assignment inside Array#forEach()',
       },
       {
+        selector: 'CallExpression[callee.property.name=forEach] ConditionalExpression',
+        message: 'Never use ternary operator inside `Array#forEach()`',
+      },
+      {
         selector: 'CallExpression[callee.type=MemberExpression][callee.property.name=/^(every|filter|find|findIndex|findLast|findLastIndex|flatMap|forEach|group|groupToMap|map|reduce|reduceRight|some)$/] IfStatement',
         message: 'Never use if in higher-order function',
       },

--- a/tests/__tests__/verify-eslint-config.js
+++ b/tests/__tests__/verify-eslint-config.js
@@ -19,6 +19,7 @@ const messageHash = {
     noIdentifierWithManagerSuffix: 'Not allowed to use "Manager" as suffix of identifier',
     noShortCircuitEvaluation: 'Use `\\?\\?` instead of short-circuit evaluation with `\\|\\|` operator',
     noSwitch: 'Never use switch',
+    noTernaryInForEach: 'Never use ternary operator inside `Array#forEach\\(\\)`',
     noWhile: 'Never use while',
   },
   'no-restricted-properties': {

--- a/tests/linted/standard$/no-restricted-syntax/$noTernaryInForEach.js
+++ b/tests/linted/standard$/no-restricted-syntax/$noTernaryInForEach.js
@@ -1,0 +1,23 @@
+const values = [1, 3, 5, 7, 9]
+
+values.forEach(it => {
+  convert({
+    value: it > 5 // ❌️ { selector: 'CallExpression[callee.property.name=forEach] ConditionalExpression' } of `no-restricted-syntax`
+      ? 'greater'
+      : 'smaller',
+  })
+})
+
+/**
+ * Converts a value based on the input parameter.
+ *
+ * @param {{
+ *   value: string
+ * }} params - Parameters for the function
+ * @returns {string} - Returns the value passed in
+ */
+function convert ({
+  value,
+}) {
+  return value
+}


### PR DESCRIPTION
# Why

* Close #526
