### PR TITLE
🧵 Adjust options of `no-restricted-syntax` rule to kick out passing not-function to higher-order function

### DIFF
--- a/lib/configurations/core-rule-option-hash.js
+++ b/lib/configurations/core-rule-option-hash.js
@@ -131,6 +131,10 @@ const coreRuleOptionHash = {
         message: 'Never use if in higher-order function',
       },
       {
+        selector: 'CallExpression[callee.type=MemberExpression][callee.property.name=/^(every|filter|find|findIndex|findLast|findLastIndex|flatMap|forEach|group|groupToMap|map|reduce|reduceRight|some)$/][arguments.0.type=Identifier]',
+        message: 'Do not pass constructors (e.g., Boolean, Number, String) to higher-order functions',
+      },
+      {
         selector: 'CallExpression[callee.type=MemberExpression][callee.property.name="reverse"]',
         message: 'Use Array#toReversed() instead of Array#reverse()',
       },

--- a/tests/__tests__/verify-eslint-config.js
+++ b/tests/__tests__/verify-eslint-config.js
@@ -18,6 +18,7 @@ const messageHash = {
     noIdentifierWithListSuffix: 'Not allowed to use "List" as suffix of identifier',
     noIdentifierWithManagerSuffix: 'Not allowed to use "Manager" as suffix of identifier',
     noShortCircuitEvaluation: 'Use `\\?\\?` instead of short-circuit evaluation with `\\|\\|` operator',
+    noConstructorPassedToHigherOrderFunc: 'Do not pass constructors \\(e\\.g\\., Boolean, Number, String\\) to higher-order functions',
     noSwitch: 'Never use switch',
     noTernaryInForEach: 'Never use ternary operator inside `Array#forEach\\(\\)`',
     noWhile: 'Never use while',

--- a/tests/linted/standard$/no-restricted-syntax/$noConstructorPassedToHigherOrderFunc.js
+++ b/tests/linted/standard$/no-restricted-syntax/$noConstructorPassedToHigherOrderFunc.js
@@ -1,0 +1,67 @@
+/* eslint-disable jsdoc/require-jsdoc */
+
+const callback = () => {}
+
+function everyFunc (array) {
+  return array.every(Boolean) // ❌ { selector: 'CallExpression[callee.property.name=every][arguments.0.type=Identifier]' } of `no-restricted-syntax`
+}
+
+function someFunc (array) {
+  return array.some(Boolean) // ❌ { selector: 'CallExpression[callee.property.name=some][arguments.0.type=Identifier]' } of `no-restricted-syntax`
+}
+
+function filterFunc (array) {
+  return array.filter(Boolean) // ❌ { selector: 'CallExpression[callee.property.name=filter][arguments.0.type=Identifier]' } of `no-restricted-syntax`
+}
+
+function findFunc (array) {
+  return array.find(Boolean) // ❌ { selector: 'CallExpression[callee.property.name=find][arguments.0.type=Identifier]' } of `no-restricted-syntax`
+}
+
+function findIndexFunc (array) {
+  return array.findIndex(Boolean) // ❌ { selector: 'CallExpression[callee.property.name=findIndex][arguments.0.type=Identifier]' } of `no-restricted-syntax`
+}
+
+function findLastFunc (array) {
+  return array.findLast(Boolean) // ❌ { selector: 'CallExpression[callee.property.name=findLast][arguments.0.type=Identifier]' } of `no-restricted-syntax`
+}
+
+function findLastIndexFunc (array) {
+  return array.findLastIndex(Boolean) // ❌ { selector: 'CallExpression[callee.property.name=findLastIndex][arguments.0.type=Identifier]' } of `no-restricted-syntax`
+}
+
+function flatMapFunc (array) {
+  return array.flatMap(Array) // ❌ { selector: 'CallExpression[callee.property.name=flatMap][arguments.0.type=Identifier]' } of `no-restricted-syntax`
+}
+
+function forEachFunc (array) {
+  array.forEach(callback) // ❌ { selector: 'CallExpression[callee.property.name=forEach][arguments.0.type=Identifier]' } of `no-restricted-syntax`
+}
+
+function mapFunc (array) {
+  return array.map(Number) // ❌ { selector: 'CallExpression[callee.property.name=map][arguments.0.type=Identifier]' } of `no-restricted-syntax`
+}
+
+function reduceFunc (array) {
+  return array.reduce(callback) // ❌ { selector: 'CallExpression[callee.property.name=reduce][arguments.0.type=Identifier]' } of `no-restricted-syntax`
+}
+
+function reduceRightFunc (array) {
+  return array.reduceRight(callback) // ❌ { selector: 'CallExpression[callee.property.name=reduceRight][arguments.0.type=Identifier]' } of `no-restricted-syntax`  )
+}
+
+export default {
+  everyFunc,
+  someFunc,
+
+  filterFunc,
+  findFunc,
+  forEachFunc,
+  findIndexFunc,
+  findLastFunc,
+  findLastIndexFunc,
+  flatMapFunc,
+  mapFunc,
+  reduceFunc,
+  reduceRightFunc,
+}


### PR DESCRIPTION
# Why

* Close #534