### PR TITLE
🧵 Adjust options of `no-restricted-syntax` to kick out `cancelled` identifier

### DIFF
--- a/lib/configurations/core-rule-option-hash.js
+++ b/lib/configurations/core-rule-option-hash.js
@@ -159,6 +159,10 @@ const coreRuleOptionHash = {
         message: 'Never use for',
       },
       {
+        selector: 'Identifier[name=/cancelled/i]',
+        message: 'Use "canceled" instead of "cancelled" as identifier',
+      },
+      {
         selector: 'Identifier[name=/.+(?<!Form|get|set|clear|inline)Data$/]',
         message: 'Not allowed to use "Data" as suffix of identifier',
       },

--- a/tests/__tests__/verify-eslint-config.js
+++ b/tests/__tests__/verify-eslint-config.js
@@ -12,6 +12,7 @@ const messageHash = {
     noIfInHigherOrderFunc: 'Never use if in higher-order function',
     noLet: 'Never use let',
     noNestedIf: 'Never use nested-if including else-if',
+    noIdentifierByCanceled: 'Use "canceled" instead of "cancelled" as identifier',
     noIdentifierWithDataSuffix: 'Not allowed to use "Data" as suffix of identifier',
     noIdentifierWithInfoSuffix: 'Not allowed to use "Info" as suffix of identifier',
     noIdentifierWithItemSuffix: 'Not allowed to use "Item" as suffix of identifier',

--- a/tests/linted/standard$/no-restricted-syntax/$noIdentifierByCanceled.js
+++ b/tests/linted/standard$/no-restricted-syntax/$noIdentifierByCanceled.js
@@ -1,0 +1,10 @@
+const cancelledAt = new Date() // ❌️ { selector: 'Identifier[name=/cancelled/i]' } of `no-restricted-syntax`
+
+class CancelledOrder { // ❌️ { selector: 'Identifier[name=/cancelled/i]' } of `no-restricted-syntax`
+  // noop
+}
+
+export default {
+  cancelledAt,
+  CancelledOrder,
+}


### PR DESCRIPTION
# Why

* Close #69