### PR TITLE
🧵 Adjust options of `no-restricted-syntax` to kick out condition branch from `constructor`

### DIFF
--- a/lib/configurations/core-rule-option-hash.js
+++ b/lib/configurations/core-rule-option-hash.js
@@ -203,6 +203,10 @@ const coreRuleOptionHash = {
         message: 'Do not use `if` statements in constructor',
       },
       {
+        selector: 'MethodDefinition[kind=constructor] BlockStatement ConditionalExpression',
+        message: 'Do not use ternary operator in constructor',
+      },
+      {
         selector: 'LogicalExpression[operator=||] > Literal',
         message: 'Use `??` instead of short-circuit evaluation with `||` operator',
       },

--- a/lib/configurations/core-rule-option-hash.js
+++ b/lib/configurations/core-rule-option-hash.js
@@ -199,6 +199,10 @@ const coreRuleOptionHash = {
         message: 'Never use nested-if including else-if',
       },
       {
+        selector: 'MethodDefinition[kind=constructor] BlockStatement IfStatement',
+        message: 'Do not use `if` statements in constructor',
+      },
+      {
         selector: 'LogicalExpression[operator=||] > Literal',
         message: 'Use `??` instead of short-circuit evaluation with `||` operator',
       },

--- a/tests/__tests__/verify-eslint-config.js
+++ b/tests/__tests__/verify-eslint-config.js
@@ -12,6 +12,8 @@ const messageHash = {
     noIfInHigherOrderFunc: 'Never use if in higher-order function',
     noLet: 'Never use let',
     noNestedIf: 'Never use nested-if including else-if',
+    noConstructorWithIfStatements: 'Do not use `if` statements in constructor',
+    noConstructorWithTernaryOperator: 'Do not use ternary operator in constructor',
     noIdentifierByCanceled: 'Use "canceled" instead of "cancelled" as identifier',
     noIdentifierWithDataSuffix: 'Not allowed to use "Data" as suffix of identifier',
     noIdentifierWithInfoSuffix: 'Not allowed to use "Info" as suffix of identifier',

--- a/tests/linted/standard$/no-restricted-syntax/$noConstructorWithIfStatements.js
+++ b/tests/linted/standard$/no-restricted-syntax/$noConstructorWithIfStatements.js
@@ -1,0 +1,16 @@
+class Alpha {
+  /**
+   * Constructor of this class.
+   *
+   * @param {*} condition
+   */
+  constructor (condition) {
+    if (condition) { // ❌ { selector: 'MethodDefinition[kind=constructor] BlockStatement IfStatement' } of `no-restricted-syntax`
+      this.value = 'value'
+    }
+  }
+}
+
+export default {
+  Alpha,
+}

--- a/tests/linted/standard$/no-restricted-syntax/$noConstructorWithTernaryOperator.js
+++ b/tests/linted/standard$/no-restricted-syntax/$noConstructorWithTernaryOperator.js
@@ -1,0 +1,16 @@
+class Alpha {
+  /**
+   * Constructor of this class.
+   *
+   * @param {*} condition
+   */
+  constructor (condition) {
+    this.value = condition // ❌️ { selector: 'MethodDefinition[kind=constructor] BlockStatement ConditionalExpression' } of `no-restricted-syntax`
+      ? 100
+      : 200
+  }
+}
+
+export default {
+  Alpha,
+}


### PR DESCRIPTION
# Why

* Close #197
