### PR TITLE
🧵 Adjust options of `no-restricted-syntax` to kick out `expect.any(Object)`

### DIFF
--- a/lib/configurations/core-rule-option-hash.js
+++ b/lib/configurations/core-rule-option-hash.js
@@ -143,6 +143,10 @@ const coreRuleOptionHash = {
         message: 'Use Array#toSorted() instead of Array#sort()',
       },
       {
+        selector: 'CallExpression[callee.type=MemberExpression][callee.object.name=expect][callee.property.name="any"][arguments.0.name=Object]',
+        message: 'Do not use expect.any(Object)',
+      },
+      {
         selector: 'DoWhileStatement',
         message: 'Never use do-while',
       },

--- a/tests/__tests__/verify-eslint-config.js
+++ b/tests/__tests__/verify-eslint-config.js
@@ -14,6 +14,7 @@ const messageHash = {
     noNestedIf: 'Never use nested-if including else-if',
     noConstructorWithIfStatements: 'Do not use `if` statements in constructor',
     noConstructorWithTernaryOperator: 'Do not use ternary operator in constructor',
+    noExpectAnyWithObject: 'Do not use expect.any\\(Object\\)',
     noIdentifierByCanceled: 'Use "canceled" instead of "cancelled" as identifier',
     noIdentifierWithDataSuffix: 'Not allowed to use "Data" as suffix of identifier',
     noIdentifierWithInfoSuffix: 'Not allowed to use "Info" as suffix of identifier',

--- a/tests/linted/standard$/no-restricted-syntax/$noExpectAnyWithObject.js
+++ b/tests/linted/standard$/no-restricted-syntax/$noExpectAnyWithObject.js
@@ -1,0 +1,8 @@
+describe('No expect.any(Object) rule', () => {
+  test('do not use expect.any(Object)', () => {
+    const actual = {}
+
+    expect(actual)
+      .toEqual(expect.any(Object)) // ❌️ { selector: 'CallExpression[callee.type=MemberExpression][callee.object.name=expect][callee.property.name="any"][arguments.0.name=Object]' } of `no-restricted-syntax`
+  })
+})


### PR DESCRIPTION
# Why

* Close #194