### PR TITLE
🧵 Adjust options of `no-restricted-syntax` to kick out calling function from `constructor`

### DIFF
--- a/lib/configurations/core-rule-option-hash.js
+++ b/lib/configurations/core-rule-option-hash.js
@@ -203,6 +203,10 @@ const coreRuleOptionHash = {
         message: 'Never use nested-if including else-if',
       },
       {
+        selector: 'MethodDefinition[kind=constructor] BlockStatement CallExpression:not([callee.type=Super])',
+        message: 'Do not call methods or functions in constructor',
+      },
+      {
         selector: 'MethodDefinition[kind=constructor] BlockStatement IfStatement',
         message: 'Do not use `if` statements in constructor',
       },

--- a/tests/__tests__/verify-eslint-config.js
+++ b/tests/__tests__/verify-eslint-config.js
@@ -12,6 +12,7 @@ const messageHash = {
     noIfInHigherOrderFunc: 'Never use if in higher-order function',
     noLet: 'Never use let',
     noNestedIf: 'Never use nested-if including else-if',
+    noConstructorWithCallingFunction: 'Do not call methods or functions in constructor',
     noConstructorWithIfStatements: 'Do not use `if` statements in constructor',
     noConstructorWithTernaryOperator: 'Do not use ternary operator in constructor',
     noExpectAnyWithObject: 'Do not use expect.any\\(Object\\)',

--- a/tests/exempted/jsdoc/imports-as-dependencies.js
+++ b/tests/exempted/jsdoc/imports-as-dependencies.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-restricted-syntax */
+
 /**
  * Lint sample for jsdoc/imports-as-dependencies rule
  */

--- a/tests/exempted/jsdoc/require-description-complete-sentence.js
+++ b/tests/exempted/jsdoc/require-description-complete-sentence.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-restricted-syntax */
+
 class RequireDescriptionCompleteSentence {
   /**
    * Constructor.

--- a/tests/exempted/no-restricted-syntax.js
+++ b/tests/exempted/no-restricted-syntax.js
@@ -1,3 +1,5 @@
+/* eslint-disable max-classes-per-file */
+
 const alpha = new FormData() // ✅️ ignore Identifier[name=/.+(?<!Form)Data$/] of `no-restricted-syntax` against FormData
 
 // -----------------------------------------------------------------------------
@@ -45,6 +47,35 @@ const gammaPayload = {
  */
 const FFUtils = null // ✅️ ignore Identifier[name=/.+(?<!FF)Utils?$/] of `no-restricted-syntax` against FFUtils
 
+// -----------------------------------------------------------------------------
+
+// For no constructor with calling function
+class DeltaClass {
+  /**
+   * Constructor of this class.
+   */
+  constructor () {
+    this.first = new Map() // ✅️ { selector: 'MethodDefinition[kind=constructor] BlockStatement CallExpression:not([callee.type=Super])' } of `no-restricted-syntax`
+    this.second = new Set() // ✅️ { selector: 'MethodDefinition[kind=constructor] BlockStatement CallExpression:not([callee.type=Super])' } of `no-restricted-syntax`
+    this.third = new WeakMap() // ✅️ { selector: 'MethodDefinition[kind=constructor] BlockStatement CallExpression:not([callee.type=Super])' } of `no-restricted-syntax`
+    this.fourth = new WeakSet() // ✅️ { selector: 'MethodDefinition[kind=constructor] BlockStatement CallExpression:not([callee.type=Super])' } of `no-restricted-syntax`
+
+    this.fifth = new Date() // ✅️ { selector: 'MethodDefinition[kind=constructor] BlockStatement CallExpression:not([callee.type=Super])' } of `no-restricted-syntax`
+    this.sixth = new Error('message') // ✅️ { selector: 'MethodDefinition[kind=constructor] BlockStatement CallExpression:not([callee.type=Super])' } of `no-restricted-syntax`
+  }
+}
+
+class EpsilonClass extends DeltaClass {
+  /**
+   * Constructor of this class.
+   */
+  constructor () {
+    super() // ✅️ { selector: 'MethodDefinition[kind=constructor] BlockStatement CallExpression:not([callee.type=Super])' } of `no-restricted-syntax`
+
+    this.last = []
+  }
+}
+
 export default {
   alpha,
   betaValue,
@@ -52,4 +83,6 @@ export default {
   isRadioNodeList,
   gammaPayload,
   FFUtils,
+  DeltaClass,
+  EpsilonClass,
 }

--- a/tests/linted/standard$/no-restricted-syntax/$noConstructorWithCallingFunction.js
+++ b/tests/linted/standard$/no-restricted-syntax/$noConstructorWithCallingFunction.js
@@ -1,0 +1,56 @@
+class Alpha {
+  /**
+   * Constructor of this class.
+   *
+   * @param {*} object
+   */
+  constructor (object) {
+    this.getInstanceValue() // ❌ { selector: 'MethodDefinition[kind=constructor] BlockStatement CallExpression:not([callee.type=Super])' } of `no-restricted-syntax`
+
+    this.Ctor.getStaticValue() // ❌ { selector: 'MethodDefinition[kind=constructor] BlockStatement CallExpression:not([callee.type=Super])' } of `no-restricted-syntax`
+
+    object.getValue(this) // ❌ { selector: 'MethodDefinition[kind=constructor] BlockStatement CallExpression:not([callee.type=Super])' } of `no-restricted-syntax`
+
+    betaFunction(this) // ❌ { selector: 'MethodDefinition[kind=constructor] BlockStatement CallExpression:not([callee.type=Super])' } of `no-restricted-syntax`
+  }
+
+  /**
+   * Get static value.
+   *
+   * @returns {number} Static value
+   */
+  static getStaticValue () {
+    return 0
+  }
+
+  /**
+   * get: Constructor.
+   *
+   * @returns {typeof Alpha} The constructor of this class
+   */
+  get Ctor () {
+    return /** @type {typeof Alpha} */ (this.constructor)
+  }
+
+  /**
+   * Get instance value.
+   *
+   * @returns {number} Instance value
+   */
+  getInstanceValue () {
+    return 999
+  }
+}
+
+/**
+ * Beta function.
+ *
+ * @param {*} instance - The instance of Alpha.
+ */
+function betaFunction (instance) {
+  instance.setup()
+}
+
+export default {
+  Alpha,
+}


### PR DESCRIPTION
# Why

* Close #538
