### PR TITLE
🧵 Adjust options `no-restricted-syntax` to kick out `await` from `if` condition

### DIFF
--- a/lib/configurations/core-rule-option-hash.js
+++ b/lib/configurations/core-rule-option-hash.js
@@ -203,6 +203,10 @@ const coreRuleOptionHash = {
         message: 'Never use nested-if including else-if',
       },
       {
+        selector: 'IfStatement[test] AwaitExpression',
+        message: 'Do not use await in if condition',
+      },
+      {
         selector: 'MethodDefinition[kind=constructor] BlockStatement CallExpression:not([callee.type=Super])',
         message: 'Do not call methods or functions in constructor',
       },

--- a/tests/__tests__/verify-eslint-config.js
+++ b/tests/__tests__/verify-eslint-config.js
@@ -4,6 +4,7 @@ import {
 
 const messageHash = {
   'no-restricted-syntax': {
+    noAwaitInIfCondition: 'Do not use await in if condition',
     noDoWhile: 'Never use do-while',
     noFor: 'Never use for',
     noForEachContainsAssignment: 'Do not use assignment inside Array#forEach\\(\\)',

--- a/tests/linted/standard$/no-restricted-syntax/$noAwaitInIfCondition.js
+++ b/tests/linted/standard$/no-restricted-syntax/$noAwaitInIfCondition.js
@@ -1,0 +1,24 @@
+/**
+ * Alpha function.
+ *
+ * @returns {Promise<void>} A promise that resolves when the function is complete.
+ */
+async function alphaFunc () {
+  if (await alphaFunc()) { // ❌ { selector: 'IfStatement[test] AwaitExpression' } of `no-restricted-syntax`
+    // Do something
+  }
+}
+
+/**
+ * Beta function.
+ *
+ * @returns {Promise<boolean>} A promise that resolves when the function is complete.
+ */
+async function betaFunc () {
+  return true
+}
+
+export default {
+  alphaFunc,
+  betaFunc,
+}


### PR DESCRIPTION
# Why

* Close #331