### PR TITLE
🧵 Adjust options `no-restricted-syntax` to kick out logic from `describe()`

### DIFF
--- a/lib/configurations/core-rule-option-hash.js
+++ b/lib/configurations/core-rule-option-hash.js
@@ -123,6 +123,10 @@ const coreRuleOptionHash = {
         message: 'Do not use `if` statements in `describe()`',
       },
       {
+        selector: 'CallExpression[callee.name=describe] ConditionalExpression',
+        message: 'Do not use ternary operator in `describe()`',
+      },
+      {
         selector: 'CallExpression[callee.property.name=forEach]:has(* VariableDeclarator)',
         message: 'Do not use assignment inside Array#forEach()',
       },

--- a/lib/configurations/core-rule-option-hash.js
+++ b/lib/configurations/core-rule-option-hash.js
@@ -119,6 +119,10 @@ const coreRuleOptionHash = {
      */
     spreadOptions: [
       {
+        selector: 'CallExpression[callee.name=describe] IfStatement',
+        message: 'Do not use `if` statements in `describe()`',
+      },
+      {
         selector: 'CallExpression[callee.property.name=forEach]:has(* VariableDeclarator)',
         message: 'Do not use assignment inside Array#forEach()',
       },

--- a/tests/__tests__/verify-eslint-config.js
+++ b/tests/__tests__/verify-eslint-config.js
@@ -16,6 +16,8 @@ const messageHash = {
     noConstructorWithCallingFunction: 'Do not call methods or functions in constructor',
     noConstructorWithIfStatements: 'Do not use `if` statements in constructor',
     noConstructorWithTernaryOperator: 'Do not use ternary operator in constructor',
+    noDescribeWithIfStatements: 'Do not use `if` statements in `describe\\(\\)`',
+    noDescribeWithTernaryOperator: 'Do not use ternary operator in `describe\\(\\)`',
     noExpectAnyWithObject: 'Do not use expect.any\\(Object\\)',
     noIdentifierByCanceled: 'Use "canceled" instead of "cancelled" as identifier',
     noIdentifierWithDataSuffix: 'Not allowed to use "Data" as suffix of identifier',

--- a/tests/linted/standard$/no-restricted-syntax/$noDescribeWithIfStatements.js
+++ b/tests/linted/standard$/no-restricted-syntax/$noDescribeWithIfStatements.js
@@ -1,0 +1,7 @@
+describe('no if in describe()', () => {
+  const condition = true
+
+  if (condition) { // ❌ { selector: 'CallExpression[callee.name="describe"] IfStatement' } of `no-restricted-syntax`
+    // noop
+  }
+})

--- a/tests/linted/standard$/no-restricted-syntax/$noDescribeWithTernaryOperator.js
+++ b/tests/linted/standard$/no-restricted-syntax/$noDescribeWithTernaryOperator.js
@@ -1,0 +1,9 @@
+/* eslint-disable no-unused-vars */
+
+describe('no ternary operator in describe()', () => {
+  const condition = true
+
+  const expected = condition // ❌ { selector: 'CallExpression[callee.name="describe"] ConditionalExpression' } of `no-restricted-syntax`
+    ? 'alpha'
+    : 'beta'
+})


### PR DESCRIPTION
# Why

* Close #50
