### PR TITLE
🧵 Adjust options of `no-restricted-syntax` to kick out static class

### DIFF
--- a/lib/configurations/core-rule-option-hash.js
+++ b/lib/configurations/core-rule-option-hash.js
@@ -155,6 +155,19 @@ const coreRuleOptionHash = {
         message: 'Do not use expect.any(Object)',
       },
       {
+        selector: 'ClassDeclaration[superClass=null]:not(:has(MethodDefinition[kind=constructor])), ClassDeclaration[superClass=null]:has(MethodDefinition[kind=constructor]):not(:has(MethodDefinition[kind=constructor] AssignmentExpression[left.object.type=ThisExpression]))',
+        // ClassDeclaration[superClass=null]:not(:has(MethodDefinition[kind=constructor])),
+        // ClassDeclaration[superClass=null]
+        //   :has(MethodDefinition[kind=constructor])
+        //   :not(
+        //     :has(
+        //       MethodDefinition[kind=constructor] AssignmentExpression[left.object.type=ThisExpression]
+        //     )
+        //   )
+        // `,
+        message: 'Do not declare static class',
+      },
+      {
         selector: 'DoWhileStatement',
         message: 'Never use do-while',
       },

--- a/tests/__tests__/verify-eslint-config.js
+++ b/tests/__tests__/verify-eslint-config.js
@@ -27,6 +27,7 @@ const messageHash = {
     noIdentifierWithManagerSuffix: 'Not allowed to use "Manager" as suffix of identifier',
     noShortCircuitEvaluation: 'Use `\\?\\?` instead of short-circuit evaluation with `\\|\\|` operator',
     noConstructorPassedToHigherOrderFunc: 'Do not pass constructors \\(e\\.g\\., Boolean, Number, String\\) to higher-order functions',
+    noStaticClass: 'Do not declare static class',
     noSwitch: 'Never use switch',
     noTernaryInForEach: 'Never use ternary operator inside `Array#forEach\\(\\)`',
     noWhile: 'Never use while',

--- a/tests/exempted/id-length.js
+++ b/tests/exempted/id-length.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-restricted-syntax */
+
 /**
  * Lint sample for id-length rule.
  */

--- a/tests/exempted/jsdoc/check-indentation.js
+++ b/tests/exempted/jsdoc/check-indentation.js
@@ -1,4 +1,5 @@
 /* eslint-disable max-classes-per-file */
+/* eslint-disable no-restricted-syntax */
 
 /**
  * Base class for testing JSDoc indentation.

--- a/tests/exempted/jsdoc/check-tag-names.js
+++ b/tests/exempted/jsdoc/check-tag-names.js
@@ -1,4 +1,5 @@
 /* eslint-disable max-classes-per-file */
+/* eslint-disable no-restricted-syntax */
 
 /**
  * Base class for testing JSDoc indentation.

--- a/tests/exempted/jsdoc/require-jsdoc.js
+++ b/tests/exempted/jsdoc/require-jsdoc.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-restricted-syntax */
+
 class RequireJsdoc { // ✅ require.ClassDeclaration:false of `jsdoc/require-jsdoc`
   // noop
 }

--- a/tests/exempted/jsdoc/text-escaping.js
+++ b/tests/exempted/jsdoc/text-escaping.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-restricted-syntax */
+
 class TextEscaping {
   /**
    * This description has <div>HTML</div> and `markdown` text. // ✅ exempted `jsdoc/text-escaping`

--- a/tests/exempted/no-restricted-syntax.js
+++ b/tests/exempted/no-restricted-syntax.js
@@ -76,6 +76,65 @@ class EpsilonClass extends DeltaClass {
   }
 }
 
+// -----------------------------------------------------------------------------
+
+/**
+ * Zeta class. (not static class)
+ */
+class ZetaClass { // ✅️ { selector: 'xxx' } of `no-restricted-syntax`
+  /**
+   * Constructor of this class.
+   *
+   * @param {{
+   *   value: number
+   * }} params - Parameters for the constructor.
+   */
+  constructor ({
+    value,
+  }) {
+    this.value = value
+  }
+
+  /**
+   * Factory method.
+   *
+   * @template {X extends typeof ZetaClass ? X : never} T, X
+   * @param {{
+   *   value: number
+   * }} params - Parameters for the factory method.
+   * @returns {InstanceType<T>} Instance of the class.
+   * @this {T}
+   */
+  static create ({
+    value,
+  }) {
+    return /** @type {InstanceType<T>} */ (
+      new this({
+        value,
+      })
+    )
+  }
+}
+
+/**
+ * Ita class.
+ */
+class ItaClass extends ZetaClass { // ✅️ { selector: 'xxx' } of `no-restricted-syntax`
+  /**
+   * Do first.
+   */
+  static doFirst () {
+    // Do something
+  }
+
+  /**
+   * Do second.
+   */
+  static doSecond () {
+    // Do something else
+  }
+}
+
 export default {
   alpha,
   betaValue,
@@ -85,4 +144,7 @@ export default {
   FFUtils,
   DeltaClass,
   EpsilonClass,
+
+  ZetaClass,
+  ItaClass,
 }

--- a/tests/exempted/require-await.js
+++ b/tests/exempted/require-await.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-restricted-syntax */
+
 /**
  * Lint sample for require-await rule.
  */

--- a/tests/linted/default$/openreachtech/empty-line-after-super.js
+++ b/tests/linted/default$/openreachtech/empty-line-after-super.js
@@ -1,4 +1,5 @@
 /* eslint-disable max-classes-per-file */
+/* eslint-disable no-restricted-syntax */
 /* eslint-disable jsdoc/require-jsdoc */
 
 class BaseClass {

--- a/tests/linted/standard$/grouped-accessor-pairs.js
+++ b/tests/linted/standard$/grouped-accessor-pairs.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax */
 /* eslint-disable jsdoc/require-jsdoc */
 
 const alpha = {

--- a/tests/linted/standard$/id-denylist.js
+++ b/tests/linted/standard$/id-denylist.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax */
 /* eslint-disable jsdoc/require-jsdoc */
 /* eslint-disable no-unused-private-class-members */
 

--- a/tests/linted/standard$/id-length.js
+++ b/tests/linted/standard$/id-length.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-restricted-syntax */
+
 /**
  * Lint sample for id-length rule.
  */

--- a/tests/linted/standard$/id-match.js
+++ b/tests/linted/standard$/id-match.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax */
 /* eslint-disable jsdoc/require-jsdoc */
 
 const 漢字 = 'kanji' // ❌ ^[\$\w]+$ of `id-match`

--- a/tests/linted/standard$/jsdoc/check-indentation.js
+++ b/tests/linted/standard$/jsdoc/check-indentation.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-restricted-syntax */
+
 class CheckIndentation {
   /**
    * There is no lint of `jsdoc/check-indentation` for param and returns tags.

--- a/tests/linted/standard$/jsdoc/tag-lines.js
+++ b/tests/linted/standard$/jsdoc/tag-lines.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-restricted-syntax */
+
 class TagLines {
   /**
    * There is empty line between `param` and `returns` (8: Expected no lines between tags).

--- a/tests/linted/standard$/max-classes-per-file.js
+++ b/tests/linted/standard$/max-classes-per-file.js
@@ -1,5 +1,6 @@
 // ❌ max:1 of `max-classes-per-file`
 
+/* eslint-disable no-restricted-syntax */
 /* eslint-disable jsdoc/require-jsdoc */
 
 class AlphaClass {

--- a/tests/linted/standard$/no-empty-function.js
+++ b/tests/linted/standard$/no-empty-function.js
@@ -1,4 +1,5 @@
 /* eslint-disable getter-return */
+/* eslint-disable no-restricted-syntax */
 /* eslint-disable jsdoc/require-jsdoc */
 /* eslint-disable object-shorthand */
 

--- a/tests/linted/standard$/no-restricted-syntax/$noConstructorWithCallingFunction.js
+++ b/tests/linted/standard$/no-restricted-syntax/$noConstructorWithCallingFunction.js
@@ -12,6 +12,8 @@ class Alpha {
     object.getValue(this) // ❌ { selector: 'MethodDefinition[kind=constructor] BlockStatement CallExpression:not([callee.type=Super])' } of `no-restricted-syntax`
 
     betaFunction(this) // ❌ { selector: 'MethodDefinition[kind=constructor] BlockStatement CallExpression:not([callee.type=Super])' } of `no-restricted-syntax`
+
+    this.alpha = null
   }
 
   /**

--- a/tests/linted/standard$/no-restricted-syntax/$noIdentifierByCanceled.js
+++ b/tests/linted/standard$/no-restricted-syntax/$noIdentifierByCanceled.js
@@ -1,7 +1,12 @@
 const cancelledAt = new Date() // ❌️ { selector: 'Identifier[name=/cancelled/i]' } of `no-restricted-syntax`
 
 class CancelledOrder { // ❌️ { selector: 'Identifier[name=/cancelled/i]' } of `no-restricted-syntax`
-  // noop
+  /**
+   * Constructor.
+   */
+  constructor () {
+    this.first = []
+  }
 }
 
 export default {

--- a/tests/linted/standard$/no-restricted-syntax/$noStaticClass.js
+++ b/tests/linted/standard$/no-restricted-syntax/$noStaticClass.js
@@ -1,0 +1,47 @@
+/* eslint-disable max-classes-per-file */
+/* eslint-disable no-unused-expressions */
+
+/**
+ * Alpha class.
+ */
+class AlphaClass { // ❌ { selector: 'xxx' } of `no-restricted-syntax`
+  /**
+   * Constructor of this class.
+   */
+  constructor () {
+    this.callFirst
+  }
+
+  /**
+   * Call first method.
+   *
+   * @returns {*}
+   */
+  get callFirst () {
+    return null
+  }
+}
+
+/**
+ * Beta class.
+ */
+class BetaClass { // ❌ { selector: 'xxx' } of `no-restricted-syntax`
+  /**
+   * Do first.
+   */
+  static doFirst () {
+    // Do something
+  }
+
+  /**
+   * Do second.
+   */
+  static doSecond () {
+    // Do something else
+  }
+}
+
+export default {
+  AlphaClass,
+  BetaClass,
+}

--- a/tests/linted/standard$/no-use-before-define.js
+++ b/tests/linted/standard$/no-use-before-define.js
@@ -1,4 +1,5 @@
 /* eslint-disable max-classes-per-file */
+/* eslint-disable no-restricted-syntax */
 /* eslint-disable jsdoc/require-jsdoc */
 
 function alphaFunc (first) {
@@ -29,7 +30,7 @@ const gamma = 3
   // @ts-expect-error
   alphaFunc(delta) // ❌ { variables: true } of `no-use-before-define`
 
-  let delta = 1 // eslint-disable-line no-restricted-syntax, prefer-const
+  let delta = 1 // eslint-disable-line prefer-const
 }
 
 // @ts-expect-error


### PR DESCRIPTION
# Why

* Close #59