### PR TITLE
Adjust options of `jsdoc/check-indentation` to add `import`

### DIFF
--- a/lib/configurations/plugins/jsdoc.js
+++ b/lib/configurations/plugins/jsdoc.js
@@ -13,6 +13,7 @@ export default {
           'description',
           'example',
           'extends',
+          'import',
           'note',
           'param',
           'returns',

--- a/tests/exempted/jsdoc/check-indentation.js
+++ b/tests/exempted/jsdoc/check-indentation.js
@@ -85,11 +85,18 @@ const deltaObject = {
   second: 'string',
 }
 
+/** @type {Epsilon} */
+const epsilonObject = {
+  first: 1,
+  second: 2,
+}
+
 export default {
   AlphaClass,
   betaFunction,
   gammaFunction,
   deltaObject,
+  epsilonObject,
 }
 
 /**
@@ -97,4 +104,10 @@ export default {
  *   first: number
  *   second: string
  * }} OmegaType // ✅️ { excludeTags: ['typedef'] } of `jsdoc/check-indentation`
+ */
+
+/**
+ * @import {
+ *   Epsilon,
+ * } from '../../../types/fixtures.js' // ✅️ { excludeTags: ['import'] } of `jsdoc/check-indentation`
  */

--- a/types/fixtures.d.ts
+++ b/types/fixtures.d.ts
@@ -1,0 +1,4 @@
+export interface Epsilon {
+  first: number
+  second: number
+}


### PR DESCRIPTION
# Why

* Close #549 

# How

* Adjust `jsdoc/check-indentation` to ignore indentation of the `@import` tag.
