### PR TITLE
🧵 Add `constructorSpy` to `languageOptions.globals`

### DIFF
--- a/lib/eslint.config.js
+++ b/lib/eslint.config.js
@@ -18,6 +18,8 @@ export default [
       globals: {
         ...globals.browser,
         ...globals.node,
+
+        constructorSpy: 'readonly',
       },
       parserOptions: {
         ecmaVersion: 'latest',


### PR DESCRIPTION
# Why

* Close #566