### PR TITLE
🧵 Adjust options of `no-restricted-syntax` for `Mangager` suffix

### DIFF
--- a/lib/configurations/core-rule-option-hash.js
+++ b/lib/configurations/core-rule-option-hash.js
@@ -209,7 +209,7 @@ const coreRuleOptionHash = {
         message: 'Not allowed to use "List" as suffix of identifier',
       },
       {
-        selector: 'Identifier[name=/.+Manager$/]',
+        selector: 'Identifier[name=/.+(?<!googleTag)Manager$/]',
         message: 'Not allowed to use "Manager" as suffix of identifier',
       },
       {

--- a/tests/exempted/no-restricted-syntax.js
+++ b/tests/exempted/no-restricted-syntax.js
@@ -27,6 +27,8 @@ document.createElement('div')
 const isRadioNodeList = value => value instanceof RadioNodeList // ✅️ ignore Identifier[name=/.+(?<!class|databaseInclude|RadioNode)List$/] of `no-restricted-syntax` against RadioNodeList
 const databaseIncludeList = [true] // ✅️ { selector: 'Identifier[name=/.+(?<!class|databaseInclude|databaseInclude|RadioNode)List$/]' } of `no-restricted-syntax` against databaseIncludeList
 
+const googleTagManager = {} // ✅️ ignore Identifier[name=/.+(?<!googleTag)Manager$/] of `no-restricted-syntax` against googleTagManager
+
 /*
  * For members of DataTransfer
  */
@@ -142,6 +144,7 @@ export default {
   RequestInfo,
   isRadioNodeList,
   databaseIncludeList,
+  googleTagManager,
 
   gammaPayload,
   FFUtils,

--- a/tests/linted/standard$/no-restricted-syntax/$noIdentifierWithManagerSuffix.js
+++ b/tests/linted/standard$/no-restricted-syntax/$noIdentifierWithManagerSuffix.js
@@ -1,10 +1,10 @@
 /* eslint-disable jsdoc/require-jsdoc */
 
-class NoSuffixManager { // ❌ { selector: 'Identifier[name=/.+Manager$/]' } of `no-restricted-syntax`
+class NoSuffixManager { // ❌ { selector: 'Identifier[name=/.+(?<!googleTag)Manager$/]' } of `no-restricted-syntax`
   constructor () {
     this.array = []
     this.user = {}
   }
 }
 
-export default NoSuffixManager // ❌ { selector: 'Identifier[name=/.+Manager$/]' } of `no-restricted-syntax`
+export default NoSuffixManager // ❌ { selector: 'Identifier[name=/.+(?<!googleTag)Manager$/]' } of `no-restricted-syntax`


### PR DESCRIPTION
# Why

* Close #558