### PR TITLE
🧩 Export `eslintCommentsPluginConfig` via `index.js`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 import configAll from './lib/eslint.config.js'
 
 export { default as coreConfig } from './lib/configurations/core.js'
+
+export { default as eslintCommentsPluginConfig } from './lib/configurations/plugins/eslint-comments.js'
 export { default as jestPluginConfig } from './lib/configurations/plugins/jest.js'
 export { default as jsdocPluginConfig } from './lib/configurations/plugins/jsdoc.js'
 export { default as openreachtechPluginConfig } from './lib/configurations/plugins/openreachtech.js'

--- a/tests/__tests__/main-exports.js
+++ b/tests/__tests__/main-exports.js
@@ -2,6 +2,7 @@ import {
   default as exportedDefault,
   coreConfig,
 
+  eslintCommentsPluginConfig,
   jestPluginConfig,
   jsdocPluginConfig,
   openreachtechPluginConfig,
@@ -13,6 +14,8 @@ import {
 import configAll from '../../lib/eslint.config.js'
 
 import expectedCoreConfig from '../../lib/configurations/core.js'
+
+import expectedEslintCommentsConfig from '../../lib/configurations/plugins/eslint-comments.js'
 import expectedJestConfig from '../../lib/configurations/plugins/jest.js'
 import expectedJsdocConfig from '../../lib/configurations/plugins/jsdoc.js'
 import expectedOpenreachtechConfig from '../../lib/configurations/plugins/openreachtech.js'
@@ -32,6 +35,13 @@ describe('main exports', () => {
     test('should export core config of the Open Reach Tech ESLint config', () => {
       expect(coreConfig)
         .toBe(expectedCoreConfig)
+    })
+  })
+
+  describe('export eslintCommentsPluginConfig', () => {
+    test('should export the ESLint Comments plugin config', () => {
+      expect(eslintCommentsPluginConfig)
+        .toBe(expectedEslintCommentsConfig)
     })
   })
 


### PR DESCRIPTION
# Why

* Close #598
